### PR TITLE
feat: Implement --excludeScopes=@scope1;@scope2 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Options
 * `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
 * `--excludePackages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
 * `--excludePrivatePackages` restrict output to not include any package marked as private
+* `--excludeScopes [list]` excludes all packages in scopes from the semicolon-seperated list (example: "@hapi;@babel")
 * `--direct look for direct dependencies only`
 
 Exclusions
@@ -109,6 +110,7 @@ license-checker --customPath customFormatExample.json
 license-checker --exclude 'MIT, MIT OR X11, BSD, ISC'
 license-checker --packages 'react@16.3.0;react-dom@16.3.0;lodash@4.3.1'
 license-checker --excludePackages 'internal-1;internal-2'
+license-checker --excludeScopes '@babel;@hapi'
 license-checker --onlyunknown
 ```
 

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -37,6 +37,7 @@ if (args.help) {
         '   --packages [list] restrict output to the packages (package@version) in the semicolon-seperated list',
         '   --excludePackages [list] restrict output to the packages (package@version) not in the semicolon-seperated list',
         '   --excludePrivatePackages restrict output to not include any package marked as private',
+        '   --excludeScopes [list] excludes all packages from the semicolon-seperated list',
         '',
         '   --version The current version',
         '   --help  The text you are reading right now :)',

--- a/lib/args.js
+++ b/lib/args.js
@@ -32,6 +32,7 @@ var nopt = require('nopt'),
         packages: String,
         excludePackages: String,
         excludePrivatePackages: Boolean,
+        excludeScopes: String,
     },
     shorts = {
         "v": ["--version"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -434,6 +434,17 @@ exports.init = function(options, callback) {
             });
         }
 
+        if(options.excludeScopes) {
+            Object.keys(filtered).forEach(function(key) {
+                let scopes = options.excludeScopes.split(';');
+                scopes.forEach(s => {
+                    if (s.trim() && key.startsWith(`${s.trim()}/`)) {
+                        delete restricted[key];
+                    }
+                });
+            });
+        }
+
         Object.keys(restricted).forEach(function(item) {
             if (toCheckforFailOn.length > 0) {
                 if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {

--- a/tests/fixtures/excludeScopes/package.json
+++ b/tests/fixtures/excludeScopes/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@scoped/one-in-a-million",
+  "version": "0.0.0",
+  "licenses": [
+    {
+      "type": "Apache License, Version 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  ]
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -122,6 +122,28 @@ describe('main tests', function() {
         });
     });
 
+    function parseAndExcludeScops(parsePath, scopes, result) {
+        return function(done) {
+            checker.init({
+                start: path.join(__dirname, parsePath),
+                excludeScopes: scopes
+            }, function(err, filtered) {
+                result.output = filtered;
+                done();
+            });
+        };
+    }
+
+    describe('should parse local with excludeScopes', function() {
+        var result={};
+        before(parseAndExcludeScops('./fixtures/excludeScopes',  "@scoped;@babel", result));
+
+        it('should exclude scope from list', function() {
+            var empty =  Object.keys(result.output).length === 0;
+            assert.ok(empty);
+        });
+    });
+
     function parseAndExclude(parsePath, licenses, result) {
         return function(done) {
             checker.init({


### PR DESCRIPTION
This option makes the license-checker ignore all packages that are in
one of the semicolon-separated list of scopes.